### PR TITLE
Dropdown menu no longer appears on 'draw' tab

### DIFF
--- a/client/application/editor.html
+++ b/client/application/editor.html
@@ -1,14 +1,14 @@
 <template name="editor">
-  <select class="editor-syntax">
-    <option value="javascript" selected="selected">JavaScript</option>
-    <option value="ruby">Ruby</option>
-    <option value="html">HTML</option>
-    <option value="css">CSS</option>
-  </select>
 
   {{#if isViewingBoard}}
    {{> blackboard}}
   {{else}}
+    <select class="editor-syntax">
+      <option value="javascript" selected="selected">JavaScript</option>
+      <option value="ruby">Ruby</option>
+      <option value="html">HTML</option>
+      <option value="css">CSS</option>
+    </select>
    {{> sharejsAce docid=currentDocId onRender=currentTabConfig id="editor"}}
   {{/if}}
 


### PR DESCRIPTION
Just prevents the syntax menu from appearing on the 'draw' tab.